### PR TITLE
Update cloudtrail module tests

### DIFF
--- a/cloudtrail/Makefile
+++ b/cloudtrail/Makefile
@@ -1,5 +1,5 @@
 .PHONY: format converge verify destroy test kitchen
-TERRAFORM_SPEC_VERSION := 0.9.4
+TERRAFORM_SPEC_VERSION := 0.9.11
 
 define execute
 	if [ -z "$(CI)" ]; then \

--- a/cloudtrail/Makefile
+++ b/cloudtrail/Makefile
@@ -8,6 +8,7 @@ define execute
 			-e AWS_REGION=$(AWS_REGION) \
 			-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
 			-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
+			-e AWS_SESSION_TOKEN=$(AWS_SESSION_TOKEN) \
 			-e USER=$(USER) \
 			-v $(shell pwd):/module \
 			-v $(HOME)/.aws:/root/.aws:ro \

--- a/cloudtrail/aws_cloudtrail.tf
+++ b/cloudtrail/aws_cloudtrail.tf
@@ -43,5 +43,5 @@ resource "aws_cloudtrail" "ct" {
   is_multi_region_trail         = "${var.is_multi_region_trail}"
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.ct.arn}"
   cloud_watch_logs_role_arn     = "${aws_iam_role.ct.arn}"
-  depends_on                    = ["aws_s3_bucket_policy.bucket"]
+  depends_on                    = ["aws_s3_bucket.bucket", "aws_s3_bucket_policy.bucket", "aws_iam_role.ct"]
 }

--- a/cloudtrail/aws_s3_bucket.tf
+++ b/cloudtrail/aws_s3_bucket.tf
@@ -22,6 +22,13 @@ resource "aws_s3_bucket" "bucket" {
   tags = {
     terraform = "true"
   }
+
+  // https://github.com/hashicorp/terraform/issues/13631
+  // There is a race condition between creation of IAM/S3 resources and when they are visible to Cloudtrail
+  // sleep a bit during IAM role creation to enable the change to propagate at AWS
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
 }
 
 resource "aws_s3_bucket_policy" "bucket" {

--- a/cloudtrail/test/fixtures/minimal/minimal.tf
+++ b/cloudtrail/test/fixtures/minimal/minimal.tf
@@ -2,13 +2,18 @@
 
 data "aws_caller_identity" "current" {}
 
+resource "random_id" "cloudtrail" {
+  prefix      = "qm-test-cloudtrail-logs-"
+  byte_length = 4
+}
+
 module "it_minimal" {
   source = "../../../" //minimal integration test
 
   aws_account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region          = "us-west-2"
   aws_cloudtrail_name = "minimal"
-  s3_bucket_name      = "qm-infra-module-ct-logs-2017-09-07"
+  s3_bucket_name      = "${random_id.cloudtrail.hex}"
 
   // required to have a repeatable test
   s3_force_destroy = true

--- a/cloudtrail/test/fixtures/minimal/minimal.tf
+++ b/cloudtrail/test/fixtures/minimal/minimal.tf
@@ -1,9 +1,11 @@
 // instantiate the cloudtrail module only supplying required parameters with the intent of really exercising the defaults
 
+data "aws_caller_identity" "current" {}
+
 module "it_minimal" {
   source = "../../../" //minimal integration test
 
-  aws_account_id      = "621293099824"            // "139710491120" // "621293099824"
+  aws_account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region          = "us-west-2"
   aws_cloudtrail_name = "minimal"
   s3_bucket_name      = "qm-infra-module-ct-logs"

--- a/cloudtrail/test/fixtures/minimal/minimal.tf
+++ b/cloudtrail/test/fixtures/minimal/minimal.tf
@@ -8,7 +8,7 @@ module "it_minimal" {
   aws_account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region          = "us-west-2"
   aws_cloudtrail_name = "minimal"
-  s3_bucket_name      = "qm-infra-module-ct-logs"
+  s3_bucket_name      = "qm-infra-module-ct-logs-2017-09-07"
 
   // required to have a repeatable test
   s3_force_destroy = true

--- a/cloudtrail/test/integration/minimal/controls/terraform_state.rb
+++ b/cloudtrail/test/integration/minimal/controls/terraform_state.rb
@@ -29,12 +29,12 @@ control 'terraform_state' do
       end
 
       describe('cloudtrail.arn') do
-        subject { outputs['cloudtrail.arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:cloudtrail:us-west-2:139710491120:trail/minimal"}) }
+        subject { outputs['cloudtrail.arn']['value'] }
+        it { is_expected.to match(/arn:aws:cloudtrail:[\w-]+:[\d]+:trail\/minimal/) }
       end
       describe('cloudtrail.cloudwatch_log_group_arn') do
-        subject { outputs['cloudtrail.cloudwatch_log_group_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => 'arn:aws:logs:us-west-2:139710491120:log-group:/aws/cloudtrail/minimal:*'}) }
+        subject { outputs['cloudtrail.cloudwatch_log_group_arn']['value'] }
+        it { is_expected.to match(/arn:aws:logs:[\w-]+:[\d]+:log-group:\/aws\/cloudtrail\/minimal:\*/) }
       end
 
       describe('cloudtrail.iam_role_name') do
@@ -42,8 +42,8 @@ control 'terraform_state' do
         it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "minimal-CloudTrailToCloudWatch"}) }
       end
       describe('cloudtrail.iam_role_arn') do
-        subject { outputs['cloudtrail.iam_role_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:iam::139710491120:role/minimal-CloudTrailToCloudWatch"}) }
+        subject { outputs['cloudtrail.iam_role_arn']['value'] }
+        it { is_expected.to match(/arn:aws:iam::[\d]+:role\/minimal-CloudTrailToCloudWatch/) }
       end
 
       describe('cloudtrail.s3_bucket_id') do

--- a/cloudtrail/test/integration/minimal/controls/terraform_state.rb
+++ b/cloudtrail/test/integration/minimal/controls/terraform_state.rb
@@ -4,6 +4,8 @@ require 'rspec/expectations'
 
 terraform_state = attribute 'terraform_state', {}
 
+expect_bucket_name = "qm-infra-module-ct-logs-2017-09-07"
+
 control 'terraform_state' do
   tf_state_json = json(terraform_state)
 
@@ -30,11 +32,11 @@ control 'terraform_state' do
 
       describe('cloudtrail.arn') do
         subject { outputs['cloudtrail.arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:cloudtrail:us-west-2:621293099824:trail/minimal"}) }
+        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:cloudtrail:us-west-2:139710491120:trail/minimal"}) }
       end
       describe('cloudtrail.cloudwatch_log_group_arn') do
         subject { outputs['cloudtrail.cloudwatch_log_group_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => 'arn:aws:logs:us-west-2:621293099824:log-group:/aws/cloudtrail/minimal:*'}) }
+        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => 'arn:aws:logs:us-west-2:139710491120:log-group:/aws/cloudtrail/minimal:*'}) }
       end
 
       describe('cloudtrail.iam_role_name') do
@@ -43,16 +45,16 @@ control 'terraform_state' do
       end
       describe('cloudtrail.iam_role_arn') do
         subject { outputs['cloudtrail.iam_role_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:iam::621293099824:role/minimal-CloudTrailToCloudWatch"}) }
+        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:iam::139710491120:role/minimal-CloudTrailToCloudWatch"}) }
       end
 
       describe('cloudtrail.s3_bucket_id') do
         subject { outputs['cloudtrail.s3_bucket_id'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "qm-infra-module-ct-logs"}) }
+        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => expect_bucket_name}) }
       end
       describe('cloudtrail.s3_bucket_arn') do
         subject { outputs['cloudtrail.s3_bucket_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:s3:::qm-infra-module-ct-logs"}) }
+        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:s3:::#{expect_bucket_name}"}) }
       end
 
     end

--- a/cloudtrail/test/integration/minimal/controls/terraform_state.rb
+++ b/cloudtrail/test/integration/minimal/controls/terraform_state.rb
@@ -4,8 +4,6 @@ require 'rspec/expectations'
 
 terraform_state = attribute 'terraform_state', {}
 
-expect_bucket_name = "qm-infra-module-ct-logs-2017-09-07"
-
 control 'terraform_state' do
   tf_state_json = json(terraform_state)
 
@@ -49,12 +47,12 @@ control 'terraform_state' do
       end
 
       describe('cloudtrail.s3_bucket_id') do
-        subject { outputs['cloudtrail.s3_bucket_id'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => expect_bucket_name}) }
+        subject { outputs['cloudtrail.s3_bucket_id']['value'] }
+        it { is_expected.to match(/^qm-test-cloudtrail-logs-[\w]+/)}
       end
       describe('cloudtrail.s3_bucket_arn') do
-        subject { outputs['cloudtrail.s3_bucket_arn'] }
-        it { is_expected.to eq({"sensitive" => false, "type" => "string", "value" => "arn:aws:s3:::#{expect_bucket_name}"}) }
+        subject { outputs['cloudtrail.s3_bucket_arn']['value'] }
+        it { is_expected.to match(/^arn:aws:s3:::qm-test-cloudtrail-logs-[\w]+/)}
       end
 
     end


### PR DESCRIPTION
```
 make destroy; make format && make converge && make verify

... snip ...

       Finished converging <minimal-aws> (0m31.53s).
-----> Kitchen is finished. (0m32.55s)
-----> Starting Kitchen (v1.15.0)
-----> Setting up <minimal-aws>...
       Finished setting up <minimal-aws> (0m0.00s).
-----> Verifying <minimal-aws>...
       Verifying host 'localhost' of group 'terraform'
       Loaded minimal

the Terraform state file
  is accessible

the Terraform state file
  outputs
    cloudtrail.id
      should eq {"sensitive"=>false, "type"=>"string", "value"=>"minimal"}
    cloudtrail.home_region
      should eq {"sensitive"=>false, "type"=>"string", "value"=>"us-west-2"}
    cloudtrail.arn
      should match /arn:aws:cloudtrail:[\w-]+:[\d]+:trail\/minimal/
    cloudtrail.cloudwatch_log_group_arn
      should match /arn:aws:logs:[\w-]+:[\d]+:log-group:\/aws\/cloudtrail\/minimal:\*/
    cloudtrail.iam_role_name
      should eq {"sensitive"=>false, "type"=>"string", "value"=>"minimal-CloudTrailToCloudWatch"}
    cloudtrail.iam_role_arn
      should match /arn:aws:iam::[\d]+:role\/minimal-CloudTrailToCloudWatch/
    cloudtrail.s3_bucket_id
      should match /^qm-test-cloudtrail-logs-[\w]+/
    cloudtrail.s3_bucket_arn
      should match /^arn:aws:s3:::qm-test-cloudtrail-logs-[\w]+/

Finished in 0.00797 seconds (files took 0.89363 seconds to load)
9 examples, 0 failures
```