### PR TITLE
Send billing alarms

### DIFF
--- a/notify/.kitchen.yml
+++ b/notify/.kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: terraform
+
+platforms:
+  - name: aws
+
+suites:
+  - name: minimal
+    provisioner:
+      name: terraform
+      apply_timeout: 600
+      color: true
+      directory: >-
+        test/fixtures/minimal
+      variables:
+        user: <%= ENV['USER'] %>
+    verifier:
+      name: terraform
+      format: doc
+      groups:
+        - name: terraform
+          controls:
+            - terraform_state

--- a/notify/Makefile
+++ b/notify/Makefile
@@ -1,0 +1,44 @@
+.PHONY: format converge verify destroy test kitchen
+TERRAFORM_SPEC_VERSION := 0.9.11
+
+define execute
+	if [ -z "$(CI)" ]; then \
+		docker run --rm -it \
+			-e AWS_PROFILE=$(AWS_PROFILE) \
+			-e AWS_REGION=$(AWS_REGION) \
+			-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
+			-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
+			-e AWS_SESSION_TOKEN=$(AWS_SESSION_TOKEN) \
+			-e USER=$(USER) \
+			-v $(shell pwd):/module \
+			-v $(HOME)/.aws:/root/.aws:ro \
+			-v $(HOME)/.netrc:/root/.netrc:ro \
+			qualimente/terraform-spec:$(TERRAFORM_SPEC_VERSION) \
+			kitchen $(1) $(KITCHEN_OPTS); \
+	else \
+		echo bundle exec kitchen $(1) $(KITCHEN_OPTS); \
+		bundle exec kitchen $(1) $(KITCHEN_OPTS); \
+	fi;
+endef
+
+format:
+	@docker run --rm -it \
+		-v $(shell pwd):/module \
+		qualimente/terraform-spec:$(TERRAFORM_SPEC_VERSION) \
+		terraform fmt
+
+converge:
+	@$(call execute,converge)
+
+verify:
+	@$(call execute,verify)
+
+destroy:
+	@$(call execute,destroy)
+
+test:
+	@$(call execute,test)
+
+kitchen:
+	@$(call execute,$(COMMAND))
+

--- a/notify/billing.tf
+++ b/notify/billing.tf
@@ -1,0 +1,29 @@
+resource "aws_sns_topic" "billing_notifications" {
+  name = "billing-notifications"
+}
+
+resource "aws_sns_topic_subscription" "https_sns_subscription_endpoint" {
+  count                  = "${length(var.https_sns_subscription_endpoint) > 0 ? 1 : 0}"
+  endpoint               = "${var.https_sns_subscription_endpoint}"
+  endpoint_auto_confirms = true
+  protocol               = "https"
+  topic_arn              = "${aws_sns_topic.billing_notifications.arn}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "max_estimated_charges_daily_alarm" {
+  alarm_name          = "max_estimated_monthly_charges"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "EstimatedCharges"
+  namespace           = "AWS/Billing"
+  period              = "${24 * 60 * 60}"
+  statistic           = "Maximum"
+  threshold           = "${var.max_estimated_daily_charges_threshold}"
+
+  dimensions {
+    Currency = "USD"
+  }
+
+  alarm_description = "Daily check of estimated monthly charges exceeded"
+  alarm_actions     = ["${aws_sns_topic.billing_notifications.arn}"]
+}

--- a/notify/interface.tf
+++ b/notify/interface.tf
@@ -1,0 +1,12 @@
+variable "max_estimated_daily_charges_threshold" {
+  description = "Maximum Allowed Estimated Charges"
+}
+
+variable "https_sns_subscription_endpoint" {
+  default     = ""
+  description = "The https endpoint where SNS notifications will be enqueued, e.g. for PagerDuty: https://events.pagerduty.com/integration/YOUR_INTEGRATION/enqueue"
+}
+
+output "notify.billing_notification_https_subscription_arn" {
+  value = "${aws_sns_topic_subscription.https_sns_subscription_endpoint.arn}"
+}

--- a/notify/test/fixtures/minimal/minimal.tf
+++ b/notify/test/fixtures/minimal/minimal.tf
@@ -1,0 +1,12 @@
+// instantiate the cloudtrail module only supplying required parameters with the intent of really exercising the defaults
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "it_minimal" {
+  source = "../../../" //minimal integration test
+
+  max_estimated_daily_charges_threshold = "300"
+  https_sns_subscription_endpoint       = "https://events.pagerduty.com/integration/d99ed3be29204c5799361c118deaba86/enqueue"
+}

--- a/notify/test/integration/minimal/controls/terraform_state.rb
+++ b/notify/test/integration/minimal/controls/terraform_state.rb
@@ -1,0 +1,31 @@
+require 'json'
+require 'rspec/expectations'
+
+
+terraform_state = attribute 'terraform_state', {}
+
+control 'terraform_state' do
+  tf_state_json = json(terraform_state)
+
+  describe 'the Terraform state file' do
+    subject { json(terraform_state).terraform_version }
+
+    it('is accessible') { is_expected.to match(/\d+\.\d+\.\d+/) }
+  end
+
+  describe 'the Terraform state file' do
+    #require 'pry'; binding.pry; #uncomment to jump into the debugger
+
+    outputs = tf_state_json.modules[1]['outputs']
+    describe 'outputs' do
+
+      describe('notify.billing_notification_https_subscription_arn') do
+        subject { outputs['notify.billing_notification_https_subscription_arn']['value'] }
+        it { is_expected.to match(/^arn:aws:sns:us-east-1:[\d]+:[\w-]+/)}
+      end
+
+    end
+
+  end
+
+end

--- a/notify/test/integration/minimal/inspec.yml
+++ b/notify/test/integration/minimal/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: minimal


### PR DESCRIPTION
Create a CloudWatch-based daily billing alarm that can be configured with:

* max charge limit
* https endpoint to send notifications to

Unfortunately, Terraform's sns_topic_subscription resource [does not support email](https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html#email) because:

> the (email/email-json/sms) endpoint needs to be authorized and does not generate an ARN until the target email address has been validated.  This breaks the Terraform (state) model and as a result are not currently supported.

(context added)

The test configures a subscriber for notifications at PagerDuty.